### PR TITLE
tigakub_FixedLinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This project adheres to the Contributor [code of conduct](CODE_OF_CONDUCT.md). B
 
 ## Documentation (WIP)
 
-* The full documentation is available at: [https://pollen-robotics.github.io/reachy-docs/](https://pollen-robotics.github.io/reachy-docs/)
-* The APIs can be found at: [https://pollen-robotics.github.io/reachy/](https://pollen-robotics.github.io/reachy/)
+* The full documentation is available at: [https://pollen-robotics.github.io/reachy-2019-docs/](https://pollen-robotics.github.io/reachy-2019-docs/)
+* The APIs can be found at: [https://pollen-robotics.github.io/reachy-2019/](https://pollen-robotics.github.io/reachy-2019/)
 
 ## Installation
 


### PR DESCRIPTION
### Identify the Bug (if you are fixing one)

The following links are broken

https://pollen-robotics.github.io/reachy-docs/
https://pollen-robotics.github.io/reachy/

### Description of the Change

Updated them to

https://pollen-robotics.github.io/reachy-2019-docs/
https://pollen-robotics.github.io/reachy-2019

### Possible Drawbacks

This is temporary. At some point someone needs to merge the pollen master with the circuitlaunch branch

### Release Notes

Fixed links to stop 401 errors.